### PR TITLE
Update PowderReduceP2D.dot

### DIFF
--- a/docs/source/diagrams/PowderReduceP2D.dot
+++ b/docs/source/diagrams/PowderReduceP2D.dot
@@ -16,7 +16,7 @@ digraph PowderReduceP2D {
     Minus               [label="Substract Container Run\nfrom Sample Run\nusing Minus v1."]
     processVanRun       [label="Process Vanadium Run\n(see workflow diagram)"]
     Divide              [label="Divide Sample Run\nby Vanadium Run\nusing Divide v1."]
-    resetNegatives2D    [label="ResetNegatives2D v1"]
+    resetNegatives2D    [label="ResetNegatives2D"]
     SaveP2D             [label="Create p2d File"]
   }
 


### PR DESCRIPTION
Removed v1 from ResetNegatives function, as it is private now.

**Description of work.**
Fixed small error in overall workflow algorithm graph.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
